### PR TITLE
Add Google Maps service

### DIFF
--- a/resources/views/services/googlemaps.blade.php
+++ b/resources/views/services/googlemaps.blade.php
@@ -1,0 +1,9 @@
+<x-embed-responsive-wrapper :aspect-ratio="$aspectRatio">
+    <iframe
+        src="{{ $iframeUrl }}"
+        frameborder="0"
+        allowfullscreen=""
+        loading="lazy"
+        referrerpolicy="no-referrer-when-downgrade"
+    ></iframe>
+</x-embed-responsive-wrapper>

--- a/src/Services/GoogleMaps.php
+++ b/src/Services/GoogleMaps.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BenSampo\Embed\Services;
+
+use Illuminate\Support\Str;
+use BenSampo\Embed\ServiceBase;
+use BenSampo\Embed\ValueObjects\Url;
+
+class GoogleMaps extends ServiceBase
+{
+    public static function detect(Url $url): bool
+    {
+        return Str::startsWith($url, [
+            'https://www.google.com/maps/embed',
+        ]);
+    }
+
+    protected function viewData(): array
+    {
+        return [
+            'iframeUrl' => $this->iframeUrl(),
+        ];
+    }
+
+    protected function viewName(): string
+    {
+        return 'googlemaps';
+    }
+
+    protected function iframeUrl(): string
+    {
+        return $this->url;
+    }
+}

--- a/tests/Rules/EmbeddableUrlTest.php
+++ b/tests/Rules/EmbeddableUrlTest.php
@@ -117,7 +117,7 @@ class EmbeddableUrlTest extends ApplicationTestCase
     {
         $url = 'https://www.real.com/video/xg4y8d';
         $rule = new EmbeddableUrl;
-        $expectedMessage = 'The url must be a URL from one of the following services: Dailymotion, Miro, Slideshare, Vimeo or YouTube.';
+        $expectedMessage = 'The url must be a URL from one of the following services: Dailymotion, GoogleMaps, Miro, Slideshare, Vimeo or YouTube.';
 
         $this->assertValidationMessage($url, $rule, $expectedMessage);
     }

--- a/tests/Services/GoogleMapsTest.php
+++ b/tests/Services/GoogleMapsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace BenSampo\Embed\Tests\Services;
+
+use BenSampo\Embed\Services\GoogleMaps;
+use BenSampo\Embed\Tests\Cases\ServiceTestCase;
+
+class GoogleMapsTest extends ServiceTestCase
+{
+    protected function serviceClass(): string
+    {
+        return GoogleMaps::class;
+    }
+    
+    protected function expectedViewName(): string
+    {
+        return 'googlemaps';
+    }
+
+    protected function expectedViewData(): array
+    {
+        return [
+            'iframeUrl' => 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2483.6803818653148!2d-0.12720032263547887!3d51.50073251118933!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487604c38c8cd1d9%3A0xb78f2474b9a45aa9!2sBig%20Ben!5e0!3m2!1sen!2suk!4v1683805199103!5m2!1sen!2suk',
+        ];
+    }
+
+    protected function validUrls(): array
+    {
+        return [
+            'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2483.6803818653148!2d-0.12720032263547887!3d51.50073251118933!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487604c38c8cd1d9%3A0xb78f2474b9a45aa9!2sBig%20Ben!5e0!3m2!1sen!2suk!4v1683805199103!5m2!1sen!2suk',
+        ];
+    }
+}


### PR DESCRIPTION
Needed it for a project, so thought why not. Accepts the iFrame `src` URL given in the HTML from Google in their 'Embed This Map' sharing window.

Could be edited to accept the whole HTML embed that Google give you, and then regex-out the unneeded stuff, but that was beyond my scope.