### PR TITLE
Added aria-label to iframe for all services

### DIFF
--- a/resources/views/services/dailymotion.blade.php
+++ b/resources/views/services/dailymotion.blade.php
@@ -1,8 +1,8 @@
 <x-embed-responsive-wrapper :aspect-ratio="$aspectRatio">
-    <iframe 
-        frameborder="0" 
-        type="text/html" 
-        src="https://www.dailymotion.com/embed/video/{{ $videoId }}" 
-        allowfullscreen>
-    </iframe>
+    <iframe
+            aria-label="{{ $label }}"
+            frameborder="0"
+            type="text/html"
+            src="https://www.dailymotion.com/embed/video/{{ $videoId }}"
+    ></iframe>
 </x-embed-responsive-wrapper>

--- a/resources/views/services/googlemaps.blade.php
+++ b/resources/views/services/googlemaps.blade.php
@@ -1,9 +1,10 @@
 <x-embed-responsive-wrapper :aspect-ratio="$aspectRatio">
     <iframe
-        src="{{ $iframeUrl }}"
-        frameborder="0"
-        allowfullscreen=""
-        loading="lazy"
-        referrerpolicy="no-referrer-when-downgrade"
+            aria-label="{{ $label }}"
+            src="{{ $iframeUrl }}"
+            frameborder="0"
+            allowfullscreen=""
+            loading="lazy"
+            referrerpolicy="no-referrer-when-downgrade"
     ></iframe>
 </x-embed-responsive-wrapper>

--- a/resources/views/services/miro.blade.php
+++ b/resources/views/services/miro.blade.php
@@ -1,3 +1,9 @@
 <x-embed-responsive-wrapper :aspect-ratio="$aspectRatio">
-    <iframe src="{{ $iframeUrl }}" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+    <iframe
+            aria-label="{{ $label }}"
+            src="{{ $iframeUrl }}"
+            frameborder="0"
+            allow="autoplay; fullscreen"
+            allowfullscreen
+    ></iframe>
 </x-embed-responsive-wrapper>

--- a/resources/views/services/slideshare.blade.php
+++ b/resources/views/services/slideshare.blade.php
@@ -1,3 +1,9 @@
 <x-embed-responsive-wrapper :aspect-ratio="$aspectRatio">
-    <iframe src="{{ $iframeUrl }}" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+    <iframe 
+            aria-label="{{ $label }}"
+            src="{{ $iframeUrl }}"
+            frameborder="0"
+            allow="autoplay; fullscreen"
+            allowfullscreen
+    ></iframe>
 </x-embed-responsive-wrapper>

--- a/resources/views/services/vimeo.blade.php
+++ b/resources/views/services/vimeo.blade.php
@@ -1,3 +1,9 @@
 <x-embed-responsive-wrapper :aspect-ratio="$aspectRatio">
-    <iframe src="https://player.vimeo.com/video/{{ $videoId }}@if($videoHash)?h={{ $videoHash}}@endif" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+    <iframe 
+            aria-label="{{ $label }}"
+            src="https://player.vimeo.com/video/{{ $videoId }}@if($videoHash)?h={{ $videoHash}}@endif"
+            frameborder="0"
+            allow="autoplay; fullscreen"
+            allowfullscreen
+    ></iframe>
 </x-embed-responsive-wrapper>

--- a/resources/views/services/youtube.blade.php
+++ b/resources/views/services/youtube.blade.php
@@ -1,8 +1,9 @@
 <x-embed-responsive-wrapper :aspect-ratio="$aspectRatio">
-    <iframe 
-        src="https://www.youtube-nocookie.com/embed/{{ $videoId }}" 
-        frameborder="0" 
-        allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" 
-        allowfullscreen>
-    </iframe>
+    <iframe
+        aria-label="foo {{ $label }}"
+        src="https://www.youtube-nocookie.com/embed/{{ $videoId }}"
+        frameborder="0"
+        allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+    ></iframe>
 </x-embed-responsive-wrapper>

--- a/src/ServiceContract.php
+++ b/src/ServiceContract.php
@@ -12,4 +12,5 @@ interface ServiceContract
     public function view(): View;
     public function cacheAndRender(): string;
     public function setAspectRatio(?Ratio $aspectRatio): ServiceContract;
+    public function setLabel(?string $label): ServiceContract;
 }

--- a/src/ViewComponents/EmbedViewComponent.php
+++ b/src/ViewComponents/EmbedViewComponent.php
@@ -14,11 +14,13 @@ class EmbedViewComponent extends Component
     protected ServiceContract $service;
     protected Url $url;
     protected ?Ratio $aspectRatio;
+    protected ?string $label;
 
-    public function __construct(string $url, string $aspectRatio = null)
+    public function __construct(string $url, string $aspectRatio = null, string $label = null)
     {
         $this->url = new Url($url);
         $this->aspectRatio = $aspectRatio ? new Ratio($aspectRatio) : null;
+        $this->label = $label;
     }
 
     public function render(): string
@@ -31,6 +33,7 @@ class EmbedViewComponent extends Component
 
         return $this->service
             ->setAspectRatio($this->aspectRatio)
+            ->setLabel($this->label)
             ->cacheAndRender();
     }
 }

--- a/tests/ServiceBaseTest.php
+++ b/tests/ServiceBaseTest.php
@@ -44,4 +44,10 @@ class ServiceBaseTest extends ApplicationTestCase
         $ratio = new Ratio('4:3');
         $this->assertEquals($ratio, $this->dummyService1->setAspectRatio($ratio)->view()->getData()['aspectRatio']);
     }
+
+    public function test_it_can_set_a_label()
+    {
+        $label = 'A different aria label';
+        $this->assertEquals($label, $this->dummyService1->setLabel($label)->view()->getData()['label']);
+    }
 }

--- a/tests/Services/DailymotionTest.php
+++ b/tests/Services/DailymotionTest.php
@@ -21,6 +21,7 @@ class DailymotionTest extends ServiceTestCase
     {
         return [
             'videoId' => 'xg4y8d',
+            'label' => 'An embedded video',
         ];
     }
 

--- a/tests/Services/GoogleMapsTest.php
+++ b/tests/Services/GoogleMapsTest.php
@@ -21,6 +21,7 @@ class GoogleMapsTest extends ServiceTestCase
     {
         return [
             'iframeUrl' => 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2483.6803818653148!2d-0.12720032263547887!3d51.50073251118933!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487604c38c8cd1d9%3A0xb78f2474b9a45aa9!2sBig%20Ben!5e0!3m2!1sen!2suk!4v1683805199103!5m2!1sen!2suk',
+            'label' => 'An embedded video',
         ];
     }
 

--- a/tests/Services/MiroTest.php
+++ b/tests/Services/MiroTest.php
@@ -38,6 +38,7 @@ class MiroTest extends ServiceTestCase
     {
         return [
             'iframeUrl' => 'https://miro.com/app/embed/o9J_kquX_s8=/?autoplay=yep',
+            'label' => 'An embedded video',
         ];
     }
 

--- a/tests/Services/SlideshareTest.php
+++ b/tests/Services/SlideshareTest.php
@@ -21,6 +21,7 @@ class SlideshareTest extends ServiceTestCase
     {
         return [
             'iframeUrl' => 'https://www.slideshare.net/slideshow/embed_code/key/6PCWPGFw9SwsAY',
+            'label' => 'An embedded video',
         ];
     }
 

--- a/tests/Services/VimeoTest.php
+++ b/tests/Services/VimeoTest.php
@@ -21,6 +21,7 @@ class VimeoTest extends ServiceTestCase
     {
         return [
             'videoId' => '148751763',
+            'label' => 'An embedded video',
         ];
     }
 

--- a/tests/Services/YouTubeTest.php
+++ b/tests/Services/YouTubeTest.php
@@ -21,6 +21,7 @@ class YouTubeTest extends ServiceTestCase
     {
         return [
             'videoId' => 'dQw4w9WgXcQ',
+            'label' => 'An embedded video',
         ];
     }
 


### PR DESCRIPTION
Hey Ben,

This PR adds aria-label to the iframe views for all services.  This is critical for accessibility, so screen readers can identify the content.  I do a lot of work for state and federal government, who have tests and requirements for this, and it's on the "Must Fix" list for a couple of projects where I'm using your package.

The PR touches a lot of files, but it's pretty simple, just adds setLabel() and friends, so the component can be used like ...

```php
    <x-embed url="{{ $myUrl }}" label="{{ $myLabel }}" class="w-48" />
```

The only difference between the way setLabel() and the existing setAspectRatio() works is that if no label is set, it will always have a default, rather than defaulting to null, as there always needs to be some kind of aria-label.  I'm defaulting it to __('An embedded video').

I've also added what I think is the test needed for this.

I've tried to keep the changes in code style to a minimum, but my PHP Storm defaults did do some re-ordering of 'use' statements and adding blank lines between class properties.  Lmk if you want me to undo those changes.